### PR TITLE
FIX: show all possible figure extensions in notebook

### DIFF
--- a/notebooks/show_cluster_in_volume.ipynb
+++ b/notebooks/show_cluster_in_volume.ipynb
@@ -131,7 +131,7 @@
    "outputs": [],
    "source": [
     "from IPython.display import Image, display\n",
-    "outputs = sorted(gg('figures/*/*.png'))\n",
+    "outputs = sorted(gg('figures/*/*.%s' % imageType))\n",
     "for o in outputs:\n",
     "    a = Image(filename=o)\n",
     "    display(a)"


### PR DESCRIPTION
Small correction to make sure that all possible file extensions will be visualized in the notebook
